### PR TITLE
chore: ignore compiled module binaries and local skill registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,15 @@ Temporary Items
 *http-client.private.env.json
 .idea/
 tempfiles/
+
+# Local tooling — Gentle AI skill registry
+.atl/
+
+# Compiled module binaries (go build outputs named after the module dir,
+# extensionless on Linux/macOS so the templates above miss them)
+/go-chi-restful-api/go-chi-restful-api
+/markdown-note-taking-app/markdown-note-taking-app
+/memkv/memkv
+/secmoney/secmoney
+/tmdbcli/tmdbcli
+/weather-service/weather-service


### PR DESCRIPTION
## What

Adds `.gitignore` rules for artifacts that kept showing up as untracked.

## Why

The existing `.gitignore` templates (toptal/GitHub) only ignore binaries **with an extension** (`*.exe`, `*.dll`, `*.so`, `*.dylib`). On Linux/macOS, `go build` produces an **extensionless** binary named after the module directory, so the templates miss them — they were appearing as untracked (e.g. `secmoney/secmoney`, `go-chi-restful-api/go-chi-restful-api`).

## Changes

- Ignore each module's self-named compiled binary, anchored with a leading `/` to avoid false positives:
  - `go-chi-restful-api`, `markdown-note-taking-app`, `memkv`, `secmoney`, `tmdbcli`, `weather-service`
- Ignore `.atl/` (local Gentle AI skill-registry tooling).

## Verification

`git check-ignore` confirms all targeted paths are ignored and `git status` is clean.